### PR TITLE
updated das-platform-building-blocks to 2.1.28

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.0
+    ref: refs/tags/2.1.28
     endpoint: SkillsFundingAgency
 
 stages:


### PR DESCRIPTION
Upgrading seems to have had no adverse effects, when setting the parameter "ContinueOnVulnerablePackageScanError" to true:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_releaseProgress?_a=release-environment-logs&releaseId=108718&environmentId=506254

"ContinueOnVulnerablePackageScanError" has been set to false, which is causing pipeline to fail, this will require dev team to resolve vulnerabilities in the code.

